### PR TITLE
Fix missing comma in linkable clients

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -116,7 +116,7 @@ var unlinkable_clients = [
         author: "Daniel Garcia Moreno",
         maturity: "Alpha",
         comments: "Matrix messaging app for GNOME written in Rust"
-    }
+    },
     {
         name: "Matrix IRCd",
         logo: "img/ircd-48px.png",


### PR DESCRIPTION
Code on `master` wasn't working.  Fixed now.