### PR TITLE
Add ability to set default Riot server

### DIFF
--- a/site.css
+++ b/site.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/site.css
+++ b/site.css
@@ -49,20 +49,26 @@ body {
     font-size: 20px;
 }
 
-.mxt_HomePage_inputBox {
+.mxt_HomePage_inputBox, .mxt_DefaultRiotServer_inputBox {
     text-align: center;
     color: #000;
     font-size: 24px;
 }
 
-.mxt_HomePage_inputBox_prompt {
+.mxt_HomePage_inputBox_prompt, .mxt_DefaultRiotServer_inputBox_prompt {
     display: inline;
     font-size: 24px;
     font-family: "Open Sans", Helvetica, Arial, sans-serif;
     margin-right: 5px;
 }
 
-.mxt_HomePage_inputBox_button {
+.mxt_DefaultRiotServer_inputBox_prompt_set {
+    background-color: #efffee;
+    border: 1px solid transparent;
+    box-shadow: 0 0 10px #afccaa;
+}
+
+.mxt_HomePage_inputBox_button, .mxt_DefaultRiotServer_inputBox_button {
     display: inline;
     border: 0px solid;
     border-radius: 5px;

--- a/src/components/DefaultRiotServer.js
+++ b/src/components/DefaultRiotServer.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/DefaultRiotServer.js
+++ b/src/components/DefaultRiotServer.js
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react'
+
+export default React.createClass({
+
+    getInitialState() {
+        var defaultRiotServer = window.localStorage.getItem('defaultRiotServer');
+        var inputClasses = 'mxt_DefaultRiotServer_inputBox_prompt' + (
+            defaultRiotServer ? ' mxt_DefaultRiotServer_inputBox_prompt_set' : '');
+        return {
+            inputClasses: inputClasses,
+            defaultRiotServer: defaultRiotServer || '',
+        }
+    },
+
+    handleSet(evt) {
+        window.localStorage.setItem('defaultRiotServer', this.state.defaultRiotServer);
+        this.setState({
+            inputClasses: 'mxt_DefaultRiotServer_inputBox_prompt mxt_DefaultRiotServer_inputBox_prompt_set',
+        });
+    },
+
+    handleClear(evt) {
+        window.localStorage.removeItem('defaultRiotServer');
+        this.setState({
+            inputClasses: 'mxt_DefaultRiotServer_inputBox_prompt',
+            defaultRiotServer: '',
+        });
+    },
+
+    handleChange(evt) {
+        this.setState({
+            inputClasses: 'mxt_DefaultRiotServer_inputBox_prompt',
+            defaultRiotServer: evt.target.value,
+        });
+    },
+
+    render() {
+        return (
+            <div className="mxt_DefaultRiotServer mxt_DefaultRiotServer_inputBox">
+                <input className={this.state.inputClasses} placeholder="e.g: https://riot.im/app" value={this.state.defaultRiotServer} onChange={this.handleChange} />
+                <button className="mxt_DefaultRiotServer_inputBox_button" onClick={this.handleSet}>Set default riot server</button>
+                <button className="mxt_DefaultRiotServer_inputBox_button" onClick={this.handleClear}>Clear default riot server</button>
+            </div>
+        );
+    }
+});

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -16,6 +16,8 @@ limitations under the License.
 
 import React from 'react'
 
+import DefaultRiotServer from './DefaultRiotServer'
+
 var linkable_clients = [
     {
         name: "Riot",
@@ -25,12 +27,13 @@ var linkable_clients = [
             srcSet: "img/riot.png, img/riot@2x.png 2x",
         },
         author: "New Vector",
-        homepage: "https://riot.im",
-        room_url(alias)  { return "https://riot.im/app/#/room/" + alias },
-        room_id_url(id)  { return "https://riot.im/app/#/room/" + id },
-        user_url(userId) { return "https://riot.im/app/#/user/" + userId },
-        msg_url(msg)     { return "https://riot.im/app/#/room/" + msg },
-        group_url(group)     { return "https://riot.im/app/#/group/" + group },
+        homepage: "https://riot.im/",
+        appUrl: "https://riot.im/app",
+        room_url(alias)  { return this.appUrl + "/#/room/" + alias },
+        room_id_url(id)  { return this.appUrl + "/#/room/" + id },
+        user_url(userId) { return this.appUrl + "/#/user/" + userId },
+        msg_url(msg)     { return this.appUrl + "/#/room/" + msg },
+        group_url(group)     { return this.appUrl + "/#/group/" + group },
         maturity: "Stable",
         comments: "Fully-featured Matrix client for Web, iOS & Android",
     },
@@ -223,6 +226,31 @@ export default React.createClass({
             var isUser = this.isUserIdValid(this.state.entity);
             var isMsg = this.isMsglinkValid(this.state.entity);
             var isGroup = this.isGroupValid(this.state.entity);
+
+            var defaultRiotServer = window.localStorage.getItem('defaultRiotServer');
+            if (defaultRiotServer) {
+                var link;
+                var riotClient = linkable_clients[0];
+                riotClient.appUrl = defaultRiotServer;
+                if (isRoom && riotClient.room_url) {
+                    link = riotClient.room_url(this.state.entity);
+                }
+                else if (isRoomId && riotClient.room_id_url) {
+                    link = riotClient.room_id_url(this.state.entity);
+                }
+                else if (isUser && riotClient.user_url) {
+                    link = riotClient.user_url(this.state.entity);
+                }
+                else if (isMsg && riotClient.msg_url) {
+                    link = riotClient.msg_url(this.state.entity);
+                }
+                else if (isGroup && riotClient.group_url) {
+                    link = riotClient.group_url(this.state.entity);
+                }
+                if (link) {
+                    window.location = link;
+                }
+            }
 
             var links;
 
@@ -445,6 +473,16 @@ export default React.createClass({
                         the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a> - get the source
                         from <a href="https://github.com/matrix-org/matrix.to">Github</a>.
                     </p>
+
+                    <h3>Set Default Riot server</h3>
+                    <p>
+                        If you would like to automatically redirect to a Riot instance when visiting a Matrix.to link,
+                        You may enter it here. If you do so this, clicking on a share link will automatically redirect
+                        statelessly with JavaScript.  This Riot server is stored only within your browser's local
+                        storage. If you would like to change this, simply visit <a href="/">Matrix.to</a> and you may
+                        update or delete your preferred Riot instance.
+                    </p>
+                    <DefaultRiotServer />
                 </div>
             </div>
         );

--- a/src/components/Site.js
+++ b/src/components/Site.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 OpenMarket Ltd
+Copyright 2019 Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This branch allows a user to set a default Riot server in their browser's localStorage so that, on visiting a link, they will be automatically redirected to their preferred Riot instance's view for the entity.

I've mostly just guessed at the copy and styling, so these will perhaps need some work.