### PR TITLE
Simplify layout of the room invite page

### DIFF
--- a/site.css
+++ b/site.css
@@ -137,6 +137,17 @@ body {
 .mxt_HomePage_link_comments {
 }
 
+.mxt_HomePage_otherLink {
+    margin-top: 25px;
+}
+
+.mxt_HomePage_otherLink_entity {
+    font-size: 12px;
+    font-family: monospace;
+    text-decoration: none;
+    color: #454545;
+}
+
 .mxt_HomePage_info {
 }
 

--- a/site.css
+++ b/site.css
@@ -63,16 +63,22 @@ body {
 }
 
 .mxt_HomePage_inputBox_button {
+    margin: 5px;
+}
+
+.mxt_HomePage_button {
     display: inline;
     border: 0px solid;
     border-radius: 5px;
     font-size: 20px;
     font-family: "Open Sans", Helvetica, Arial, sans-serif;
     padding: 7px 14px 7px 14px;
-    margin: 5px;
     background-color: #454545;
     color: #fff;
     font-weight: bold;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
 }
 
 .mxt_HomePage_error {
@@ -104,39 +110,28 @@ body {
 }
 
 .mxt_HomePage_link_logo,
-.mxt_HomePage_link_name,
 .mxt_HomePage_link_author,
 .mxt_HomePage_link_maturity,
-.mxt_HomePage_link_link,
 .mxt_HomePage_link_instructions,
 .mxt_HomePage_link_comments {
     display: table-cell;
     padding: 5px;
+    vertical-align: middle;
 }
 
 .mxt_HomePage_link_logo {
-    vertical-align: top;
     text-align: center;
-    padding-right: 15px;
-}
-
-.mxt_HomePage_link_name {
 }
 
 .mxt_HomePage_link_author {
 }
 
-.mxt_HomePage_link_homepage {
-    font-size: 12px;
-}
-
 .mxt_HomePage_link_maturity {
 }
 
-.mxt_HomePage_link_link {
-}
-
 .mxt_HomePage_link_instructions {
+    white-space: nowrap;
+    padding-right: 15px;
 }
 
 .mxt_HomePage_link_comments {

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -249,34 +249,36 @@ export default React.createClass({
                 description = <span>the <b>{ this.state.entity }</b> group</span>;
             }
 
+            let connectBlurb;
+            if (description) {
+                connectBlurb = <p>To connect to { description }, please select an app:</p>;
+            }
+            else {
+                connectBlurb = <p>To connect, please select an app:</p>;
+            }
+
             links = (
                 <div key="links" className="mxt_HomePage_links">
                     <div className="mxt_HomePage_links_intro">
                         <p>
                             <a href="https://matrix.org">Matrix</a> is an ecosystem for open and interoperable communication.
                         </p>
-                        <p>
-                            To connect to { description }, please select an app:
-                        </p>
+                        { connectBlurb }
                     </div>
 
                     <div className="mxt_HomePage_link mxt_HomePage_link_title">
+                        <div className="mxt_HomePage_link_instructions">
+                            Select an app
+                        </div>
                         <div className="mxt_HomePage_link_logo">
-                        </div>
-                        <div className="mxt_HomePage_link_name">
-                            Name
-                        </div>
+                        </div> 
                         <div className="mxt_HomePage_link_comments">
-                            Description
                         </div>
-                        <div className="mxt_HomePage_link_author">
+                       <div className="mxt_HomePage_link_author">
                             Author
                         </div>
                         <div className="mxt_HomePage_link_maturity">
                             Maturity
-                        </div>
-                        <div className="mxt_HomePage_link_link">
-                            Access { isMsg ? "message" : <b>{ this.state.entity }</b> }
                         </div>
                     </div>
 
@@ -308,16 +310,14 @@ export default React.createClass({
 
                         return (
                             <div key={ client.name } className="mxt_HomePage_link">
-                                <div className="mxt_HomePage_link_logo">
-                                    <a href={ link }>{ logo }</a>
+                                <div className="mxt_HomePage_link_instructions">
+                                    <a href={ link } className="mxt_HomePage_button">Use { client.name }</a>
                                 </div>
-                                <div className="mxt_HomePage_link_name">
-                                    <a href={ link }>{ client.name }</a>
-                                    <div className="mxt_HomePage_link_homepage">
-                                        <a href={ client.homepage }>{ client.homepage }</a>
-                                    </div>
+                                <div className="mxt_HomePage_link_logo">
+                                    { logo }
                                 </div>
                                 <div className="mxt_HomePage_link_comments">
+                                    <span><a href={ client.homepage }>{ client.name }</a>: </span>
                                     { client.comments }
                                 </div>
                                 <div className="mxt_HomePage_link_author">
@@ -325,9 +325,6 @@ export default React.createClass({
                                 </div>
                                 <div className="mxt_HomePage_link_maturity">
                                     { client.maturity }
-                                </div>
-                                <div className="mxt_HomePage_link_link">
-                                    <a href={ link }>{ link }</a>
                                 </div>
                             </div>
                         );
@@ -357,16 +354,15 @@ export default React.createClass({
 
                         return (
                             <div key={ client.name } className="mxt_HomePage_link">
-                                <div className="mxt_HomePage_link_logo">
-                                    <a href={ client.homepage }>{ logo }</a>
+                                <div className="mxt_HomePage_link_instructions">
+                                    <span>Using { client.name }: </span><br/>
+                                    <span>{ instructions }</span>
                                 </div>
-                                <div className="mxt_HomePage_link_name">
-                                    <a href={ client.homepage }>{ client.name }</a>
-                                    <div className="mxt_HomePage_link_homepage">
-                                        <a href={ client.homepage }>{ client.homepage }</a>
-                                    </div>
+                                <div className="mxt_HomePage_link_logo">
+                                    { logo }
                                 </div>
                                 <div className="mxt_HomePage_link_comments">
+                                    <span><a href={ client.homepage }>{ client.name }</a>: </span>
                                     { client.comments }
                                 </div>
                                 <div className="mxt_HomePage_link_author">
@@ -375,34 +371,25 @@ export default React.createClass({
                                 <div className="mxt_HomePage_link_maturity">
                                     { client.maturity }
                                 </div>
-                                <div className="mxt_HomePage_link_instructions">
-                                    { instructions }
-                                </div>
                             </div>
                         );
                     })}
-
-                    <p>
-                        To add clients to this list, <a href="https://matrix.to/#/#matrix-dev:matrix.org">please contact us</a> or
-                        simply send us a pull request <a href="https://github.com/matrix-org/matrix.to">on github</a>!
-                    </p>
                 </div>
             );
 
-            prompt = [
-                <div key="inputbox" className="mxt_HomePage_inputBox">
-                    <a href={ link } className="mxt_HomePage_inputBox_link">{ link }</a>
-                    { error }
-                </div>,
-                links
-            ];
+            if (error) {
+                prompt = [error, links];
+            }
+            else {
+                prompt = [ links ];
+            }
         }
         else {
             prompt = [
                 <div key="inputBox" className="mxt_HomePage_inputBox">
                     <form onSubmit={ this.onSubmit }>
                         <input autoFocus className="mxt_HomePage_inputBox_prompt" value={ this.state.entity } ref="prompt" size="36" type="text" placeholder="#room:example.com, @user:example.com or +group:example.com" />
-                        <input className="mxt_HomePage_inputBox_button" type="submit" value="Get link!" />
+                        <input className="mxt_HomePage_inputBox_button mxt_HomePage_button" type="submit" value="Get link!" />
                     </form>
                     { error }
                 </div>,
@@ -444,6 +431,10 @@ export default React.createClass({
                         As with all of Matrix, Matrix.to is released as open source under the terms of
                         the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a> - get the source
                         from <a href="https://github.com/matrix-org/matrix.to">Github</a>.
+                    </p>
+                    <p>
+                        To add clients to the list, <a href="https://matrix.to/#/#matrix-dev:matrix.org">please contact us</a> or
+                        simply send us a pull request <a href="https://github.com/matrix-org/matrix.to">on github</a>!
                     </p>
                 </div>
             </div>

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -377,11 +377,15 @@ export default React.createClass({
                 </div>
             );
 
+            var otherLink = (
+                <div className="mxt_HomePage_otherLink">Connect URL: <a className="mxt_HomePage_otherLink_entity" href={ link }>{ link }</a></div>
+            );
+
             if (error) {
-                prompt = [error, links];
+                prompt = [ error, links, otherLink ];
             }
             else {
-                prompt = [ links ];
+                prompt = [ links, otherLink ];
             }
         }
         else {


### PR DESCRIPTION
I found the room invite pages are somewhat confusing to me and to others #69, so here is one suggestion how one might reorganize the information on it. Probably there's still quite a bit room for improvement in the UX (e.g. how to join with Riot desktop/mobile app is unclear in the original and the revised pages?).

![screenshot2](https://user-images.githubusercontent.com/35046/80311672-8571da80-87d0-11ea-8157-52512fcb4e5a.png)
Put the most important information needed to join the room leftmost.

Replace URL link with a first-time user friendly "Use {app}" button.
Don't show the invite URL which can be complex-looking.

Show each of the links only at a single place, to avoid confusion.  Move
the app homepage link to appear together with the app description, so
that where the link goes is clearer.

Don't show the URL at the bottom of the page: the user can find it in
the URL bar if necessary.

For invites, the room description may be missing, so just say "the room"
instead.

Show the connect URL on the page, in case it's useful for some apps