### PR TITLE
Fix Matrix-Static room_id_url link

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -40,7 +40,7 @@ var linkable_clients = [
         author: "Michael Telatynski",
         homepage: "https://github.com/t3chguy/matrix-static",
         room_url(alias) { return "https://view.matrix.org/alias/" + alias.replace(/#/g, '%23') },
-        room_id_url(id) { return "https://view.matrix.org/room/" + id },
+        room_id_url(id) { return "https://view.matrix.org/room/" + id.split("?")[0] + "/" },
         maturity: "Stable",
         comments: "A static golang generated preview of public world readable Matrix rooms.",
     },


### PR DESCRIPTION
Currently, matrix.to links from Riot if opened, create a Matrix-Static link that leads to a 404 page. This fixes that issue.

Can be tried with this link: <https://matrix.to/#/!mjbDjyNsRXndKLkHIe:matrix.org?via=matrix.org&via=mozilla.org&via=privacytools.io>. Go here then attempt to open in Matrix-Static.