### PR TITLE
Tried adding Telegram

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -44,6 +44,16 @@ var linkable_clients = [
         maturity: "Stable",
         comments: "A static golang generated preview of public world readable Matrix rooms.",
     },
+    {
+        name: "Telegram",
+        logo: "https://tiny.cc/telegramicon",
+        author: "Pavel Durov",
+        homepage: "https://telegram.org",
+        room_url(alias) { return "https://telegram.me/" + alias.replace(/#/g, '') },
+        room_id_url(id) { return "https://telegram.me/" + id },
+        maturity: "Alpha",
+        comments: "Possibly bridged room to Telegram Messenger with the same name, try at own risk",
+    },
 ];
 
 var unlinkable_clients = [


### PR DESCRIPTION
Might prove useful for bridged rooms. I hope I didn't mess anything up, I think it would be better to just take the name of the room without the domain name, maybe I'll try that as well soon. so for example a room with the id #jitsithecall:chagaifriedlander.cf will show on the Telegram section [telegram.me/jitsithecall](https://telegram.me/jitsithecall). I think it might even be useful to have both links so you can try them both out or have people able to manually edit this link - don't know if that makes sense but it would be nice. Also I did not manage to add the icon correctly so I just added a url to an icon, hope that works otherwise a png file can easily be added...