### PR TITLE
Fix enter to submit behaviour

### DIFF
--- a/src/components/CreateLinkTile.tsx
+++ b/src/components/CreateLinkTile.tsx
@@ -78,7 +78,6 @@ const LinkNotCreatedTile: React.FC<ILinkNotCreatedTileProps> = (
                             values.identifier
                     );
                 }}
-                validateOnChange={false}
             >
                 {(formik): JSX.Element => (
                     <Form>
@@ -127,7 +126,7 @@ const LinkCreatedTile: React.FC<ILinkCreatedTileProps> = (props) => {
                 onClick={(): void => props.setLink('')}
             >
                 <div>New link</div>
-                <img src={refreshIcon} />
+                <img src={refreshIcon} alt="Go back to matrix.to home page" />
             </button>
             <a href={props.link}>
                 <h1>{props.link}</h1>


### PR DESCRIPTION
fixes: https://github.com/matrix-org/matrix.to/issues/111

Validating only on blur blocked enter to submit from working if formik had marked a field as invalid on a prior blur.
Validate on change had been disabled because the input error was being displayed too early, however changes in the logic for when the error message is displayed due to the design review resolved this issue.