### PR TITLE
Make identifier regexes closer to the spec

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -16,13 +16,13 @@ import {
  */
 type Verifier<A> = [RegExp, A];
 export const roomVerifiers: Verifier<LinkKind.Alias | LinkKind.RoomId>[] = [
-    [/^#([^/:]+?):(.+)$/, LinkKind.Alias],
-    [/^!([^/:]+?):(.+)$/, LinkKind.RoomId],
+    [/^#([^:]*):(.+)$/, LinkKind.Alias],
+    [/^!([^:]*):(.+)$/, LinkKind.RoomId],
 ];
 export const verifiers: Verifier<LinkKind>[] = [
-    [/^[!#]([^/:]+?):(.+?)\/\$([^/:]+?)$/, LinkKind.Permalink],
-    [/^@([^/:]+?):(.+)$/, LinkKind.UserId],
-    [/^\+([^/:]+?):(.+)$/, LinkKind.GroupId],
+    [/^[!#]([^:]*):(.+)\/\$([^:]+):(.+)$/, LinkKind.Permalink],
+    [/^@([^:]+):(.+)$/, LinkKind.UserId],
+    [/^\+([^:]+):(.+)$/, LinkKind.GroupId],
     ...roomVerifiers,
 ];
 


### PR DESCRIPTION
fixes: #62
fixes: #113

Because of the slightly more complex url parsing of the new matrix.to we can accept slashes in the identifiers.
Room aliases and room ids are simply considered opaque strings and therefore it is valid for them to be empty strings.

Please do check these carefully, I'm a little worried they may be too leniant.

https://matrix.org/docs/spec/appendices#identifier-grammar