### PR TITLE
Future proof schemas by making them nonstrict

### DIFF
--- a/src/matrix-cypher/schemas/EventSchema.ts
+++ b/src/matrix-cypher/schemas/EventSchema.ts
@@ -17,14 +17,14 @@ limitations under the License.
 import { object, string, TypeOf } from 'zod';
 
 const EventSchema = object({
-  content: object({}).nonstrict(),
-  type: string(),
-  event_id: string(),
-  sender: string(),
-  origin_server_ts: string(),
-  unsigned: object({}).nonstrict().optional(),
-  room_id: string(),
-});
+    content: object({}).nonstrict(),
+    type: string(),
+    event_id: string(),
+    sender: string(),
+    origin_server_ts: string(),
+    unsigned: object({}).nonstrict().optional(),
+    room_id: string(),
+}).nonstrict();
 
 export type Event = TypeOf<typeof EventSchema>;
 export default EventSchema;

--- a/src/matrix-cypher/schemas/PublicRoomsSchema.ts
+++ b/src/matrix-cypher/schemas/PublicRoomsSchema.ts
@@ -17,27 +17,25 @@ limitations under the License.
 import { object, array, string, boolean, number, TypeOf } from 'zod';
 
 export const RoomSchema = object({
-  aliases: array(string()).optional(),
-  canonical_alias: string().optional(),
-  name: string().optional(),
-  num_joined_members: number(),
-  room_id: string(),
-  topic: string().optional(),
-  world_readable: boolean(),
-  guest_can_join: boolean(),
-  avatar_url: string().optional(),
-});
-
+    aliases: array(string()).optional(),
+    canonical_alias: string().optional(),
+    name: string().optional(),
+    num_joined_members: number(),
+    room_id: string(),
+    topic: string().optional(),
+    world_readable: boolean(),
+    guest_can_join: boolean(),
+    avatar_url: string().optional(),
+}).nonstrict();
 
 const PublicRoomsSchema = object({
-  chunk: array(RoomSchema),
-  next_batch: string().optional(),
-  prev_batch: string().optional(),
-  total_room_count_estimate: number().optional(),
-});
+    chunk: array(RoomSchema),
+    next_batch: string().optional(),
+    prev_batch: string().optional(),
+    total_room_count_estimate: number().optional(),
+}).nonstrict();
 
 export type Room = TypeOf<typeof RoomSchema>;
 export type PublicRooms = TypeOf<typeof PublicRoomsSchema>;
 
 export default PublicRoomsSchema;
-

--- a/src/matrix-cypher/schemas/RoomAliasSchema.ts
+++ b/src/matrix-cypher/schemas/RoomAliasSchema.ts
@@ -17,10 +17,9 @@ limitations under the License.
 import { object, array, string, TypeOf } from 'zod';
 
 const RoomAliasSchema = object({
-  room_id: string(),
-  servers: array(string()),
-});
+    room_id: string(),
+    servers: array(string()),
+}).nonstrict();
 
 export type RoomAlias = TypeOf<typeof RoomAliasSchema>;
 export default RoomAliasSchema;
-

--- a/src/matrix-cypher/schemas/UserSchema.ts
+++ b/src/matrix-cypher/schemas/UserSchema.ts
@@ -17,10 +17,9 @@ limitations under the License.
 import { object, string, TypeOf } from 'zod';
 
 const UserSchema = object({
-  avatar_url: string().optional(),
-  displayname: string().optional(),
-})
+    avatar_url: string().optional(),
+    displayname: string().optional(),
+}).nonstrict();
 
 export type User = TypeOf<typeof UserSchema>;
 export default UserSchema;
-

--- a/src/matrix-cypher/schemas/WellKnownSchema.ts
+++ b/src/matrix-cypher/schemas/WellKnownSchema.ts
@@ -17,13 +17,13 @@ limitations under the License.
 import { object, string, TypeOf } from 'zod';
 
 const WellKnownSchema = object({
-  'm.homeserver': object({
-    'base_url': string().url(),
-  }),
-  'm.identity_server': object({
-    'base_url': string().url(),
-  }),
-});
+    'm.homeserver': object({
+        base_url: string().url(),
+    }),
+    'm.identity_server': object({
+        base_url: string().url(),
+    }).optional(),
+}).nonstrict();
 
 export type WellKnown = TypeOf<typeof WellKnownSchema>;
 export default WellKnownSchema;


### PR DESCRIPTION
The schemas are a little too strict. This pr future proofs them a little bit by being lenient towards having extra non-specified fields present in the root of each schema. This technically allows the typed objects to have any keys but those key object pairs that are specified in the schema are still strictly required.

fixes: #114