### PR TITLE
Remove link around generated invite

### DIFF
--- a/src/components/CreateLinkTile.tsx
+++ b/src/components/CreateLinkTile.tsx
@@ -128,9 +128,7 @@ const LinkCreatedTile: React.FC<ILinkCreatedTileProps> = (props) => {
                 <div>New link</div>
                 <img src={refreshIcon} alt="Go back to matrix.to home page" />
             </button>
-            <a href={props.link}>
-                <h1>{props.link}</h1>
-            </a>
+            <h1>{props.link}</h1>
             <Button
                 flashChildren={'Copied'}
                 icon={copyIcon}


### PR DESCRIPTION
The link was making it hard to copy the invite without using the button on desktop. An alternative option could have been to reduce the link bounding box but it's awkward to do. Since the link was simply an easter egg to make debugging a little easier I see no harm in removing it.

fixes: #116