### PR TITLE
Pass args to clients

### DIFF
--- a/src/clients/Element.io.ts
+++ b/src/clients/Element.io.ts
@@ -36,23 +36,25 @@ const Element: LinkedClient = {
     experimental: false,
     clientId: ClientId.Element,
     toUrl: (link) => {
+        const params = link.arguments.originalParams.toString();
+        const prefixedParams = params ? `?${params}` : '';
         switch (link.kind) {
             case LinkKind.Alias:
             case LinkKind.RoomId:
                 return new URL(
-                    `https://app.element.io/#/room/${link.identifier}`
+                    `https://app.element.io/#/room/${link.identifier}${prefixedParams}`
                 );
             case LinkKind.UserId:
                 return new URL(
-                    `https://app.element.io/#/user/${link.identifier}`
+                    `https://app.element.io/#/user/${link.identifier}${prefixedParams}`
                 );
             case LinkKind.Permalink:
                 return new URL(
-                    `https://app.element.io/#/room/${link.identifier}`
+                    `https://app.element.io/#/room/${link.identifier}${prefixedParams}`
                 );
             case LinkKind.GroupId:
                 return new URL(
-                    `https://app.element.io/#/group/${link.identifier}`
+                    `https://app.element.io/#/group/${link.identifier}${prefixedParams}`
                 );
         }
     },

--- a/src/components/HomeserverOptions.stories.tsx
+++ b/src/components/HomeserverOptions.stories.tsx
@@ -34,7 +34,7 @@ export const Default: React.FC = () => (
     <HomeserverOptions
         link={{
             identifier: '#banter:matrix.org',
-            arguments: { vias: [] },
+            arguments: { vias: [], originalParams: new URLSearchParams() },
             kind: LinkKind.Alias,
             originalLink: 'This is all made up',
         }}

--- a/src/components/InviteTile.stories.tsx
+++ b/src/components/InviteTile.stories.tsx
@@ -42,6 +42,7 @@ const userLink: SafeLink = {
     identifier: '@jorik:matrix.org',
     arguments: {
         vias: [],
+        originalParams: new URLSearchParams(),
     },
     originalLink: 'asdfsadf',
 };
@@ -51,6 +52,7 @@ const roomLink: SafeLink = {
     identifier: '#element-dev:matrix.org',
     arguments: {
         vias: [],
+        originalParams: new URLSearchParams(),
     },
     originalLink: 'asdfsadf',
 };

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -127,7 +127,7 @@ const LinkPreview: React.FC<IProps> = ({ link }: IProps) => {
     let content: JSX.Element;
     const [showHSOptions, setShowHSOPtions] = useState(false);
 
-    const hses = useHSs({link});
+    const hses = useHSs({ link });
 
     if (!hses.length) {
         content = (
@@ -169,7 +169,7 @@ const LinkPreview: React.FC<IProps> = ({ link }: IProps) => {
             link={{
                 kind: LinkKind.UserId,
                 identifier: link.arguments.sharer,
-                arguments: { vias: [] },
+                arguments: { vias: [], originalParams: new URLSearchParams() },
                 originalLink: '',
             }}
         />

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -92,6 +92,7 @@ export function parseArgs(args: string): Arguments {
         vias: params.getAll('via'),
         client: bottomExchange(params.get('client')),
         sharer: bottomExchange(params.get('sharer')),
+        originalParams: params,
     };
 }
 

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -4,6 +4,8 @@ export interface Arguments {
     client?: string;
     // MXID
     sharer?: string;
+    // Original params
+    originalParams: URLSearchParams;
 }
 
 export interface LinkContent {


### PR DESCRIPTION
fixes: #147

This passes all of the original params through to the client. This is valid except perhaps in the case of the sharer param. Though I do see a use for this param for the clients it could be seen as leaking personal information to the HS.