### PR TITLE
fix: Update footer URL path to existing branch

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -54,7 +54,7 @@ const Footer: React.FC = () => {
         <div className="footer">
             <a href="https://github.com/matrix-org/matrix.to">GitHub</a>
             {' · '}
-            <a href="https://github.com/matrix-org/matrix.to/tree/matrix-two/src/clients">
+            <a href="https://github.com/matrix-org/matrix.to/tree/main/src/clients">
                 Add your client
             </a>
             {clear}


### PR DESCRIPTION
In the footer there's a link to add clients to the tree of this
repository, which pointed to a branch that did not exist in the
repository anymore. As such GitHub rendered a 404. This change points to
the footer URL to the `main` branch, which should exist as it's the
default branch for this project.