### PR TITLE
Fix punctuation of Weechat client description

### DIFF
--- a/src/open/clients/Weechat.js
+++ b/src/open/clients/Weechat.js
@@ -26,7 +26,7 @@ export class Weechat {
     get author() { return "Poljar"; }
     get homepage() { return "https://github.com/poljar/weechat-matrix"; }
 	get platforms() { return [Platform.Windows, Platform.macOS, Platform.Linux]; }
-	get description() { return 'Command-line Matrix interface using Weechat'; }
+	get description() { return 'Command-line Matrix interface using Weechat.'; }
 	getMaturity(platform) { return Maturity.Beta; }
 	getDeepLink(platform, link) {}
 	canInterceptMatrixToLinks(platform) { return false; }


### PR DESCRIPTION
Weechat's description was missing a period:

![image](https://user-images.githubusercontent.com/1342360/101813840-279ec280-3b15-11eb-89b7-20efb3e38dbf.png)
