### PR TITLE
Allow deeplinking into Nheko via matrix: scheme

### DIFF
--- a/src/open/clients/Nheko.js
+++ b/src/open/clients/Nheko.js
@@ -28,7 +28,33 @@ export class Nheko {
 	get platforms() { return [Platform.Windows, Platform.macOS, Platform.Linux]; }
 	get description() { return 'A native desktop app for Matrix that feels more like a mainstream chat app.'; }
 	getMaturity(platform) { return Maturity.Beta; }
-	getDeepLink(platform, link) {}
+	getDeepLink(platform, link) {
+		if (platform === Platform.Linux || platform === Platform.Windows) {
+			let identifier = encodeURIComponent(link.identifier.substring(1));
+			let isRoomid = link.identifier.substring(0, 1) === '!';
+			let fragmentPath;
+			switch (link.kind) {
+				case LinkKind.User:
+					fragmentPath = `u/${identifier}?action=chat`;
+					break;
+				case LinkKind.Room:
+				case LinkKind.Event:
+					if (isRoomid)
+						fragmentPath = `roomid/${identifier}`;
+					else
+						fragmentPath = `r/${identifier}`;
+
+					if (link.kind === LinkKind.Event)
+						fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
+					fragmentPath += '?action=join';
+					fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
+					break;
+				case LinkKind.Group:
+					return;
+			}
+			return `matrix:${fragmentPath}`;
+		}
+	}
 	canInterceptMatrixToLinks(platform) { return false; }
 
 	getLinkInstructions(platform, link) {


### PR DESCRIPTION
Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

This is maybe a bit of an ugly workaround, since it basically only implements this for Nheko, but I think this may be a good start and it can be generalized at a later point? It works in my local testing and in the future, we may want to not have this in the client section but instead have a big continue button at the top and the client commands only as a fallback. But some design team would need to look at that and for now this works pretty well.