### PR TITLE
Add a legal disclaimer view

### DIFF
--- a/src/RootView.js
+++ b/src/RootView.js
@@ -35,8 +35,7 @@ export class RootView extends TemplateView {
                     t.li(externalLink(t, "https://github.com/matrix-org/matrix.to/tree/main/src/open/clients", "Add your app")),
                     t.li({className: {hidden: vm => !vm.hasPreferences}},
                         t.button({className: "text", onClick: () => vm.clearPreferences()}, "Clear preferences")),
-                    t.li(
-                        t.button({className: "text", onClick: () => vm.openLink("/#/disclaimer/")}, "Disclaimer")),
+                    t.li(t.a({href: "#/disclaimer/"}, "Disclaimer")),
                 ])
             ])
         ]);

--- a/src/RootView.js
+++ b/src/RootView.js
@@ -18,10 +18,12 @@ import {TemplateView} from "./utils/TemplateView.js";
 import {OpenLinkView} from "./open/OpenLinkView.js";
 import {CreateLinkView} from "./create/CreateLinkView.js";
 import {LoadServerPolicyView} from "./policy/LoadServerPolicyView.js";
+import {DisclaimerView} from "./disclaimer/DisclaimerView.js";
 
 export class RootView extends TemplateView {
     render(t, vm) {
         return t.div({className: "RootView"}, [
+            t.mapView(vm => vm.showDisclaimer, disclaimer => disclaimer ? new DisclaimerView() : null),
             t.mapView(vm => vm.openLinkViewModel, vm => vm ? new OpenLinkView(vm) : null),
             t.mapView(vm => vm.createLinkViewModel, vm => vm ? new CreateLinkView(vm) : null),
             t.mapView(vm => vm.loadServerPolicyViewModel, vm => vm ? new LoadServerPolicyView(vm) : null),
@@ -33,6 +35,8 @@ export class RootView extends TemplateView {
                     t.li(externalLink(t, "https://github.com/matrix-org/matrix.to/tree/main/src/open/clients", "Add your app")),
                     t.li({className: {hidden: vm => !vm.hasPreferences}},
                         t.button({className: "text", onClick: () => vm.clearPreferences()}, "Clear preferences")),
+                    t.li(
+                        t.button({className: "text", onClick: () => vm.openLink("/#/disclaimer/")}, "Disclaimer")),
                 ])
             ])
         ]);

--- a/src/RootViewModel.js
+++ b/src/RootViewModel.js
@@ -29,6 +29,7 @@ export class RootViewModel extends ViewModel {
         this.openLinkViewModel = null;
         this.createLinkViewModel = null;
         this.loadServerPolicyViewModel = null;
+        this.showDisclaimer = false;
         this.preferences.on("canClear", () => {
             this.emitChange();
         });
@@ -50,11 +51,23 @@ export class RootViewModel extends ViewModel {
         this.emitChange();
     }
 
+    _showDisclaimer() {
+        this.showDisclaimer = true;
+        this.link = null;
+        this.openLinkViewModel = null;
+        this.createLinkViewModel = null;
+        this.loadServerPolicyViewModel = null;
+        this.emitChange();
+    }
+
     updateHash(hash) {
+        this.showDisclaimer = false;
         if (hash.startsWith("#/policy/")) {
             const server = hash.substr(9);
             this.loadServerPolicyViewModel = new LoadServerPolicyViewModel(this.childOptions({server}));
             this.loadServerPolicyViewModel.load();
+        } else if (hash.startsWith("#/disclaimer/")) {
+            this._showDisclaimer();
         } else {
             const oldLink = this.link;
             this.link = Link.parse(hash);

--- a/src/disclaimer/DisclaimerView.js
+++ b/src/disclaimer/DisclaimerView.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import {TemplateView} from "../utils/TemplateView.js";
 
 export class DisclaimerView extends TemplateView {

--- a/src/disclaimer/DisclaimerView.js
+++ b/src/disclaimer/DisclaimerView.js
@@ -1,0 +1,17 @@
+import {TemplateView} from "../utils/TemplateView.js";
+
+export class DisclaimerView extends TemplateView {
+    render(t) {
+        return t.div({ className: "DisclaimerView card" }, [
+            t.h1("Disclaimer"),
+            t.p(
+                'Matrix.to is a service provided by the Matrix.org Foundation ' +
+                'which allows you to easily create invites to Matrix rooms and accounts, ' +
+                'regardless of your Matrix homeserver. The service is provided "as is" without ' +
+                'warranty of any kind, either express, implied, statutory or otherwise. ' +
+                'The Matrix.org Foundation shall not be responsible or liable for the room ' +
+                'and account contents shared via this service.'
+            ),
+        ]);
+    }
+}


### PR DESCRIPTION
For #222.

Hope this is roughly the way to go for adding one. I figure another JS-based view is easier than duplicating all the footer and HTML structure for a standalone static page. I am leaving this as a draft because navigation is a little finicky - pressing "back" from the disclaimer page doesn't take me where I'd expect. I'm not sure if it's something I did.