### PR TITLE
Hide links when opening policy, show policy when navigated after load

### DIFF
--- a/src/RootViewModel.js
+++ b/src/RootViewModel.js
@@ -50,13 +50,22 @@ export class RootViewModel extends ViewModel {
         this.emitChange();
     }
 
+    _hideLinks() {
+        this.link = null;
+        this.openLinkViewModel = null;
+        this.createLinkViewModel = null;
+    }
+
     updateHash(hash) {
         if (hash.startsWith("#/policy/")) {
             const server = hash.substr(9);
+            this._hideLinks();
             this.loadServerPolicyViewModel = new LoadServerPolicyViewModel(this.childOptions({server}));
             this.loadServerPolicyViewModel.load();
+            this.emitChange();
         } else {
             const oldLink = this.link;
+            this.loadServerPolicyViewModel = null;
             this.link = Link.parse(hash);
             this._updateChildVMs(oldLink);
         }


### PR DESCRIPTION
This would fix #224. I know that the current policy link opens in a new tab, which is why this isn't normally noticeable, but it's still possible to navigate to `/policy` via the browser (and it shows up in the URL completion bar).