### PR TITLE
Added chat.fedoraproject.org to list of trusted Elements

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -20,6 +20,7 @@ import {Maturity, Platform, LinkKind,
 const trustedWebInstances = [
     "app.element.io",   // first one is the default one
     "develop.element.io",
+    "chat.fedoraproject.org",
     "chat.fosdem.org",
     "chat.mozilla.org",
     "webchat.kde.org",


### PR DESCRIPTION
The Element Web and the server fedora.im is hosted and managed by EMS