### PR TITLE
Add basic support for matrix-URIs (MSC2312)

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -17,9 +17,9 @@ limitations under the License.
 import {createEnum} from "./utils/enum.js";
 import {orderedUnique} from "./utils/unique.js";
 
-const ROOMALIAS_PATTERN = /^#([^:]*):(.+)$/;
-const ROOMID_PATTERN = /^!([^:]*):(.+)$/;
-const USERID_PATTERN = /^@([^:]+):(.+)$/;
+const ROOMALIAS_PATTERN = /^(?:(?:#)|(?:(?:matrix:)?r\/))([^:]*):(.+)$/;
+const ROOMID_PATTERN = /^(?:(?:!)|(?:(?:matrix:)?roomid\/))([^:]*):(.+)$/;
+const USERID_PATTERN = /^(?:(?:@)|(?:(?:matrix:)?u\/))([^:]*):(.+)$/;
 const EVENTID_PATTERN = /^$([^:]+):(.+)$/;
 const GROUPID_PATTERN = /^\+([^:]+):(.+)$/;
 
@@ -111,7 +111,21 @@ export class Link {
             return null;
         }
         linkStr = linkStr.substr(2);
-        const [identifier, eventId] = linkStr.split("/");
+
+        let [identifier, eventId] = linkStr.split("/");
+
+        if(linkStr.startsWith("matrix:") || linkStr.startsWith("u/") || linkStr.startsWith("roomid/")) {
+            const split = linkStr.split("/");
+
+            if(split.length < 2) return null;
+            
+            identifier = split.slice(0, 2).join("/");
+            eventId = null;
+
+            if(split.length === 4 && split[2] === "e") {
+                eventId = split[3];
+            }
+        }
 
         let viaServers = [];
         let clientId = null;


### PR DESCRIPTION
Hello all,

This pull request implements basic support for processing matrix-URIs as defined in matrix-org/matrix-doc#2312.

Included in this pull request:
- Support for user-URIs (e.g. https://matrix.to/#/matrix:u/kevin:1in1.net)
- Support for room-URIs (e.g. https://matrix.to/#/matrix:r/test:1in1.net)
- Support for roomid-URIs (e.g. https://matrix.to/#/matrix:roomid/ytjjUgXREIginfVYtV:1in1.net)
- Support for event-IDs (e.g. https://matrix.to/#/matrix:roomid/ytjjUgXREIginfVYtV:1in1.net/e/$vdTHSNXPjDsTVBeVjcLrbmgWCOWhbGAkT9TnfqvuJXM)

See also: #205

Hope this helps, let me know if you'd like something changed or if there is something I've overlooked!

-- Kevin