### PR TITLE
Add twitter embed meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="twitter:image" content="https://matrix.org/blog/img/matrix-logo.png"/>
 	<meta property="twitter:site" content="@matrixdotorg"/>
 	<meta property="twitter:title" content="Matrix - Decentralised and secure communication"/>
-	<meta property="twitter:description" content="Matrix is an open source project that publishes the Matrix open standard for secure, decentralised, real-time communication, and its Apache licensed reference implementations."/>
+	<meta property="twitter:description" content="You're invited to talk on Matrix. If you don't already have a client this link will help you pick one, and join the conversation. If you already have one, this link will help you join the conversation"/>
 </head>
 <body>
     <script id="main" type="module">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <meta name="description" content="You're invited to talk on Matrix">
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <link rel="stylesheet" type="text/css" href="css/main.css">
+    <meta property="twitter:card" content="summary"/>
+    <meta property="twitter:image" content="https://matrix.org/blog/img/matrix-logo.png"/>
+	<meta property="twitter:site" content="@matrixdotorg"/>
+	<meta property="twitter:title" content="Matrix - An open standard for decentralised secure communication"/>
+	<meta property="twitter:description" content="Matrix is an open source project that publishes the Matrix open standard for secure, decentralised, real-time communication, and its Apache licensed reference implementations."/>
 </head>
 <body>
     <script id="main" type="module">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta property="twitter:card" content="summary"/>
     <meta property="twitter:image" content="https://matrix.org/blog/img/matrix-logo.png"/>
 	<meta property="twitter:site" content="@matrixdotorg"/>
-	<meta property="twitter:title" content="Matrix - An open standard for decentralised secure communication"/>
+	<meta property="twitter:title" content="Matrix - Decentralised and secure communication"/>
 	<meta property="twitter:description" content="Matrix is an open source project that publishes the Matrix open standard for secure, decentralised, real-time communication, and its Apache licensed reference implementations."/>
 </head>
 <body>


### PR DESCRIPTION
Add embeds to make matrix invite links more obvious on twitter.

Links to matrix rooms are easily lost on twitter, especially if the same tweet includes a link to a site with embed support, example:
![image](https://user-images.githubusercontent.com/12273817/143042235-9087d5f6-c6e2-4f22-af65-075ff576cb7f.png)

Add meta tags for twitter so that if matrix.to links are posted first, they will be used for the embed, this will make them more obvious / appealing to click, this PR will result in tweets with matrix.to links looking like the following instead:

![image](https://user-images.githubusercontent.com/12273817/143042581-4760e3ff-1004-4642-aea3-676f7ca7e0e2.png)

The title/description is just pulled from matrix.org, maintainers may want to make this something matrix.to specific or choose something that better represents the platform in this context.