### PR TITLE
Apply URL encoding to the fragmentPath

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -72,7 +72,7 @@ export class Element {
             if (isWebPlatform && trustedWebInstances.includes(link.webInstances[this.id])) {
                 instanceHost = link.webInstances[this.id];
             }
-            return `https://${instanceHost}/#/${fragmentPath}`;
+            return `https://${instanceHost}/#/${encodeURIComponent(fragmentPath)}`;
         } else if (platform === Platform.Linux || platform === Platform.Windows || platform === Platform.macOS) {
             return `element://vector/webapp/#/${encodeURIComponent(fragmentPath)}`;
         } else {

--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -74,9 +74,9 @@ export class Element {
             }
             return `https://${instanceHost}/#/${fragmentPath}`;
         } else if (platform === Platform.Linux || platform === Platform.Windows || platform === Platform.macOS) {
-            return `element://vector/webapp/#/${fragmentPath}`;
+            return `element://vector/webapp/#/${encodeURIComponent(fragmentPath)}`;
         } else {
-            return `element://${fragmentPath}`;
+            return `element://${encodeURIComponent(fragmentPath)}`;
         }
     }
 


### PR DESCRIPTION
According to [RFC3986 section 3.5](https://www.rfc-editor.org/rfc/rfc3986), only certain values are legal in the fragment. # in particular isn't one of them - its not a "pchar", but this is a character that appears in room names.

This seems to cause element:// urls to fail to load Element on OS X; it might cause issues elsewhere as well.

It shouldn't hurt to escape other, otherwise legal characters in the fragment such as @ and :.

Fixes https://github.com/vector-im/element-web/issues/17446
Fixes https://github.com/matrix-org/matrix.to/issues/230