### PR TITLE
Remove url encoding from android element:// links

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -76,7 +76,7 @@ export class Element {
         } else if (platform === Platform.Linux || platform === Platform.Windows || platform === Platform.macOS) {
             return `element://vector/webapp/#/${encodeURIComponent(fragmentPath)}`;
         } else {
-            return `element://${encodeURIComponent(fragmentPath)}`;
+            return `element://${fragmentPath}`;
         }
     }
 


### PR DESCRIPTION
#248 introduced url encoding for the android element:// link but this caused a regression because the encoded url cannot be picked up by android's filters.  See #259 

This returns the android url to its previous form which still worked.


Fixes #259 