### PR TITLE
Update link to trusted web clients in the README and attempt to future-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ https://matrix.to/#/#matrix:matrix.org?web-instance[element.io]=chat.mozilla.org
 
 - `client`, e.g. `client=im.fluffychat`, `client=element.io`
 - `web-instance[]`, e.g. `web-instance[element.io]=chat.mozilla.org`.
-    - For [matrix.to](https://matrix.to/), we have this list of [trusted web instances](https://github.com/matrix-org/matrix.to/blob/260d2b61cdb6b0e4318bc1bd59b4e2deef86d2a5/src/open/clients/Element.js#L20-L25) configured.
+    - For [matrix.to](https://matrix.to/), we have a list of [trusted web instances configured](src/open/clients/Element.js) (see `trustedWebInstances`).
 -  `via`, e.g. `via=mozilla.org`
 
 You can discuss matrix.to in


### PR DESCRIPTION
matrix.to has a list of trusted web-based Matrix clients to redirect to. The README contained a link pointing to this `trustedWebInstances` allowlist array *at a specific commit*. This information became outdated when we updated the list.

This PR changes the link to always point to the latest commit, with some direction about where to look. It will also become outdated if we move the file or change the variable name, but that's less likely to happen than pushing a new commit.