### PR TITLE
Copy deep link when using Element client

### DIFF
--- a/src/open/ClientView.js
+++ b/src/open/ClientView.js
@@ -82,8 +82,8 @@ class InstallClientView extends TemplateView {
                 className: "copy",
                 title: "Copy instructions",
                 "aria-label": "Copy instructions",
-                onClick: evt => {
-                    if (copy(vm.copyString, copyButton.parentElement)) {
+                onClick: async (evt) => {
+                    if (await copy(vm.copyString, copyButton.parentElement)) {
                         copyButton.className = "tick";
                         setTimeout(() => {
                             copyButton.className = "copy";

--- a/src/utils/copy.js
+++ b/src/utils/copy.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 - 2022 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,14 +22,21 @@ function selectNode(node) {
     selection.addRange(range);
 }
 
-export function copy(text, parent) {
-    const span = document.createElement("span");
-    span.innerText = text;
-    parent.appendChild(span);
-    selectNode(span);
-    const result = document.execCommand("copy");
-    parent.removeChild(span);
-    return result;
+export async function copy(text, parent) {
+    if ("clipboard" in navigator) {
+        const type = "text/plain";
+        const blob = new Blob([text], { type });
+        const data = [new ClipboardItem({ [type]: blob })];
+        return navigator.clipboard.write(data);
+    } else {
+        const span = document.createElement("span");
+        span.innerText = text;
+        parent.appendChild(span);
+        selectNode(span);
+        const result = document.execCommand("copy");
+        parent.removeChild(span);
+        return result;
+    }
 }
 
 export function copyButton(t, getCopyText, label, classNames) {


### PR DESCRIPTION
Addresses the first bullet point in the alternative solutions of https://github.com/matrix-org/matrix.to/issues/263
Will be a first step to help with https://github.com/vector-im/element-web/issues/22821

# What does this do? 

Uses the "clipboard hack" to add the URL of the room the user tries to join. This helps restore the client to the correct state after the user goes through the signup flow.

It also make sure the "Continue" button does not dissapear from under your feet after being clicked on mobile
