### PR TITLE
Add `app.gitter.im` as a trusted web instance

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -24,7 +24,7 @@ const trustedWebInstances = [
     "chat.fosdem.org",
     "chat.mozilla.org",
     "webchat.kde.org",
-    "app.gitter.im"
+    "app.gitter.im",
 ];
 
 /**

--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -24,6 +24,7 @@ const trustedWebInstances = [
     "chat.fosdem.org",
     "chat.mozilla.org",
     "webchat.kde.org",
+    "app.gitter.im"
 ];
 
 /**


### PR DESCRIPTION
Add `app.gitter.im` as a trusted web instance

`app.gitter.im` is the Gitter branded Element instance since Gitter full migrated to Matrix ([context](https://blog.gitter.im/2023/02/13/gitter-has-fully-migrated-to-matrix/))

Usage:

```
https://matrix.to/#/#gitter_gitter:gitter.im?web-instance[element.io]=app.gitter.im
```