### PR TITLE
Fix desktop Element download link

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -92,7 +92,7 @@ export class Element {
         switch (platform) {
             case Platform.iOS: return [new AppleStoreLink('vector', 'id1083446067')];
             case Platform.Android: return [new PlayStoreLink('im.vector.app'), new FDroidLink('im.vector.app')];
-            default: return [new WebsiteLink("https://element.io/get-started")];
+            default: return [new WebsiteLink("https://element.io/download")];
         }
     }
 


### PR DESCRIPTION
The previous link now leads to a page that says "Contact Sales".