### PR TITLE
Add Cloudflare Pages headers file

### DIFF
--- a/cloudflare/_headers
+++ b/cloudflare/_headers
@@ -1,0 +1,3 @@
+# Remove the ACAO header which is added by default on Cloudflare Pages
+/*
+  ! Access-Control-Allow-Origin

--- a/cloudflare/_headers
+++ b/cloudflare/_headers
@@ -1,3 +1,7 @@
 # Remove the ACAO header which is added by default on Cloudflare Pages
 /*
   ! Access-Control-Allow-Origin
+
+# Add ACAO header for images
+/images/*
+  Access-Control-Allow-Origin: *

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node scripts/serve-local.js",
-    "build": "node scripts/build.js"
+    "build": "node scripts/build.js && cp cloudflare/_headers build/"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
PoC - disable the default behaviour of adding `access-control-allow-origin: *` to pages sites

Enable ACAO only for static `/images/`

Available at:

https://cf-pages-headers.matrix-to-asy.pages.dev/


The deployment mechanism probably needs looking at (writing into the build.js file).

Reference:

https://github.com/vector-im/sre-internal/issues/2606