### PR TITLE
Update NeoChat client description

### DIFF
--- a/src/open/clients/NeoChat.js
+++ b/src/open/clients/NeoChat.js
@@ -23,7 +23,7 @@ export class NeoChat {
     get icon() { return "images/client-icons/org.kde.neochat.svg"; }
     get author() { return "Tobias Fella and Carl Schwan"; }
     get homepage() { return "https://apps.kde.org/neochat/"; }
-    get platforms() { return [Platform.Linux]; }
+    get platforms() { return [Platform.Linux, Platform.Windows]; }
     get description() { return 'NeoChat is a convergent, cross-platform Matrix client.'; }
     getMaturity(platform) { return Maturity.Beta; }
     getDeepLink(platform, link) {


### PR DESCRIPTION
This PR adds marks windows support for the NeoChat client, so that it shows up in the client list for windows users too.

The [Matrix Clients page](https://matrix.org/ecosystem/clients/neochat/) of it also marks macos by a link to an installer, and I also know of an android app published on a custom F-droid repo of theirs, but as these are not mentioned on [the app's official webpage](https://apps.kde.org/neochat/), I haven't added them here either.