### PR TITLE
Add Element X iOS entries in the apple-app-site-association.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 *.tar.gz
 /.idea
+.DS_Store

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -124,7 +124,7 @@ async function buildJs(mainFile, assets, extraFiles = []) {
 }
 
 function buildAppleAssociatedAppsFile(clients) {
-    const appIds = clients.map(c => c.appleAssociatedAppId).filter(id => !!id);
+    const appIds = clients.map(c => c.appleAssociatedAppId).flat().filter(id => !!id);
     return JSON.stringify({
         "applinks": {
             "apps": [],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -127,7 +127,6 @@ function buildAppleAssociatedAppsFile(clients) {
     const appIds = clients.map(c => c.appleAssociatedAppId).flat().filter(id => !!id);
     return JSON.stringify({
         "applinks": {
-            "apps": [],
             "details": {
                 appIDs: appIds,
                 components: [
@@ -136,9 +135,6 @@ function buildAppleAssociatedAppsFile(clients) {
                     }
                 ]
             },
-        },
-        "webcredentials": {
-            "apps": appIds
         }
     });
 }

--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -42,7 +42,14 @@ export class Element {
     }
 
     get icon() { return "images/client-icons/element.svg"; }
-    get appleAssociatedAppId() { return "7J4U792NQT.im.vector.app"; }
+    get appleAssociatedAppId() { 
+        return [
+            "7J4U792NQT.im.vector.app",
+            "7J4U792NQT.io.element.elementx",
+            "7J4U792NQT.io.element.elementx.nightly",
+            "7J4U792NQT.io.element.elementx.pr"
+        ]; 
+    }
     get name() {return "Element"; }
     get description() { return 'Fully-featured Matrix client, used by millions.'; }
     get homepage() { return "https://element.io"; }


### PR DESCRIPTION
This PR makes 2 changes:
- Add Element X app IDs to Element's client definition.
- Tidy up the generated [site association file](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
    - The empty `apps` array isn't expected for `applinks` definition so I removed it.
    - The `webcredentials` definition is to support password filling on the site, which as far as I understand it, matrix.to doesn't have any login form, so I removed this too.

The generated file looks like this after these changes:
```json
{
  "applinks": {
    "details": {
      "appIDs": [
        "7J4U792NQT.im.vector.app",
        "7J4U792NQT.io.element.elementx",
        "7J4U792NQT.io.element.elementx.nightly",
        "7J4U792NQT.io.element.elementx.pr"
      ],
      "components": [
        {
          "#": "/*"
        }
      ]
    }
  }
}
```