### PR TITLE
Fix the apple-app-site-association file.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -127,14 +127,17 @@ function buildAppleAssociatedAppsFile(clients) {
     const appIds = clients.map(c => c.appleAssociatedAppId).flat().filter(id => !!id);
     return JSON.stringify({
         "applinks": {
-            "details": {
-                appIDs: appIds,
-                components: [
-                    {
-                        "#": "/*",  // only open urls with a fragment, so you can still create links
-                    }
-                ]
-            },
+            "details": [
+                {
+                    appIDs: appIds,
+                    components: [
+                        {
+                            "#": "/*",
+                            "comment": "Only open urls with a fragment, so you can still create links"
+                        }
+                    ]
+                }
+            ]
         }
     });
 }


### PR DESCRIPTION
It seems the file had an error where `details` was a single object instead of an array of objects. This PR fixes it to match the documentation: https://developer.apple.com/documentation/bundleresources/applinks

**Generated file:**
```
{
  "applinks": {
    "details": [
      {
        "appIDs": [
          "7J4U792NQT.im.vector.app",
          "7J4U792NQT.io.element.elementx",
          "7J4U792NQT.io.element.elementx.nightly",
          "7J4U792NQT.io.element.elementx.pr"
        ],
        "components": [
          {
            "#": "/*",
            "comment": "Only open urls with a fragment, so you can still create links"
          }
        ]
      }
    ]
  }
}
```