### PR TITLE
Improve domain splitting for "Hosted by" header

### DIFF
--- a/src/open/ClientViewModel.js
+++ b/src/open/ClientViewModel.js
@@ -137,9 +137,9 @@ export class ClientViewModel extends ViewModel {
         const preferredWebInstance = this._client.getPreferredWebInstance(this._link);
         if (this._webPlatform && preferredWebInstance) {
             let label = preferredWebInstance;
-            const subDomainIdx = preferredWebInstance.lastIndexOf(".", preferredWebInstance.lastIndexOf("."));
+            const subDomainIdx = preferredWebInstance.lastIndexOf(".", preferredWebInstance.lastIndexOf(".") - 1);
             if (subDomainIdx !== -1) {
-                label = preferredWebInstance.slice(preferredWebInstance.length - subDomainIdx + 1);
+                label = preferredWebInstance.slice(subDomainIdx + 1);
             }
             return `Hosted by ${label}`;
         }


### PR DESCRIPTION
If a preferred web instance is set, an additional "Hosted by example.com" label is shown. This label is supposed to display only the main domain without subdomains, so if "element.example.com" is set, we show "Hosted by example.com". However, the logic doesn't do that at all (in only works by accident for domains where the subdomain is exactly one character longer than the TLD, matching the quite common `chat.something.org` or `app.something.io` structure).

![image](https://github.com/user-attachments/assets/cb4a7da1-f970-491b-8881-d6709d954234)

The proposed code is still somewhat flawed as it wouldn't work properly for e.g. a `chat.example.co.uk` domain (displaying `Hosted on co.uk`), but at least it works for the currently trusted instances.