### PR TITLE
Add Blender Chat to Trusted Instances

### DIFF
--- a/src/open/clients/Element.js
+++ b/src/open/clients/Element.js
@@ -25,6 +25,7 @@ const trustedWebInstances = [
     "chat.mozilla.org",
     "webchat.kde.org",
     "app.gitter.im",
+    "chat.blender.org",
 ];
 
 /**


### PR DESCRIPTION
This would make using query parameter `web-instance[element.io]=chat.blender.org` for linking to our Element Web instance (https://chat.blender.org) on https://matrix.to feasible.