### PR TITLE
Handle avatar load errors with placeholder

### DIFF
--- a/src/preview/PreviewView.js
+++ b/src/preview/PreviewView.js
@@ -46,7 +46,19 @@ class LoadedPreviewView extends TemplateView {
     render(t, vm) {
         const avatar = t.map(vm => vm.avatarUrl, (avatarUrl, t) => {
             if (avatarUrl) {
-                return t.img({className: "avatar", src: avatarUrl});
+                return t.img({
+                    className: "avatar",
+                    src: avatarUrl,
+                    onerror: function(event) {
+                        const avatarContainer = event.target.parentNode;
+                        if (avatarContainer) {
+                            avatarContainer.replaceChild(
+                                t.div({className: "defaultAvatar"}),
+                                event.target
+                            );
+                        }
+                    }
+                });
             } else {
                 return t.div({className: "defaultAvatar"});
             }


### PR DESCRIPTION
This PR updates matrix.to to use the default avatar placeholder when media authentication is not supported.

Currently, matrix.to attempts to load user avatars from authenticated media endpoints it cannot access. As a result, it displays broken or unreachable images, which negatively affects the user experience (see #351)

Changes:

* Added an `onerror` handler to the avatar image in `LoadedPreviewView` (`src/preview/PreviewView.js`) so that if the image fails to load, it is replaced with a default avatar element.

This ensures the UI remains clean and consistent, even when avatar images are unavailable.