### PR TITLE
docs: Clarify matrix.to URL scheme for Spaces on README (fixes #393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The matrix.to URL scheme is
 The #/ component is mandatory and exists to avoid leaking the target URL to the
 server hosting matrix.to.
 
+There is no _Entity type_ for **Spaces**, as they are technically really just regular
+rooms. (Some servers call their "entrypoint" space literally `space`, in which case
+the URL would be `https://matrix.to/#/#space:example.org`.) 
+
 Note that linking to rooms by ID should only be used for rooms to which the
 target user has been invited: these links cannot be assumed to work for all
 visitors.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The matrix.to URL scheme is
 The #/ component is mandatory and exists to avoid leaking the target URL to the
 server hosting matrix.to.
 
-There is no _Entity type_ for **Spaces**, as they are technically really just rooms.
+There is no _Entity type_ for **Spaces**, as they are technically just rooms.
 
 Note that linking to rooms by ID should only be used for rooms to which the
 target user has been invited: these links cannot be assumed to work for all

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ The matrix.to URL scheme is
 The #/ component is mandatory and exists to avoid leaking the target URL to the
 server hosting matrix.to.
 
-There is no _Entity type_ for **Spaces**, as they are technically really just regular
-rooms. (Some servers call their "entrypoint" space literally `space`, in which case
-the URL would be `https://matrix.to/#/#space:example.org`.) 
+There is no _Entity type_ for **Spaces**, as they are technically really just rooms.
 
 Note that linking to rooms by ID should only be used for rooms to which the
 target user has been invited: these links cannot be assumed to work for all


### PR DESCRIPTION
Fixes #393.