### PR TITLE
fix(scripts): switch from fs.rmdir to fs.rm

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -164,7 +164,7 @@ async function buildCss(entryPath, targetDir, assets) {
 
 async function removeDirIfExists(targetDir) {
     try {
-        await fs.rmdir(targetDir, {recursive: true});
+        await fs.rm(targetDir, {recursive: true});
     } catch (err) {
         if (err.code !== "ENOENT") {
             throw err;


### PR DESCRIPTION
The recursive option was already deprecated in node v14.14.0 (2020-10-15), but has now been permanently removed in v25.0.0 (2025-10-15).

https://nodejs.org/api/fs.html#fsrmdirpath-options-callback