### PR TITLE
Directly open Matrix URI when showing link

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -216,4 +216,30 @@ export class Link {
             return `/${this.identifier}`;
         }
     }
+
+    static toMatrixUri(link) {
+        let identifier = encodeURIComponent(link.identifier.substring(1));
+        let isRoomid = link.identifier.substring(0, 1) === '!';
+        let fragmentPath;
+        switch (link.kind) {
+            case LinkKind.User:
+                fragmentPath = `u/${identifier}?action=chat`;
+                break;
+            case LinkKind.Room:
+            case LinkKind.Event:
+                if (isRoomid)
+                    fragmentPath = `roomid/${identifier}`;
+                else
+                    fragmentPath = `r/${identifier}`;
+
+                if (link.kind === LinkKind.Event)
+                    fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
+                fragmentPath += '?action=join';
+                fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
+                break;
+            case LinkKind.Group:
+                return;
+        }
+        return `matrix:${fragmentPath}`;
+    }
 }

--- a/src/open/OpenLinkViewModel.js
+++ b/src/open/OpenLinkViewModel.js
@@ -21,6 +21,7 @@ import {PreviewViewModel} from "../preview/PreviewViewModel.js";
 import {ServerConsentViewModel} from "./ServerConsentViewModel.js";
 import {getLabelForLinkKind} from "../Link.js";
 import {orderedUnique} from "../utils/unique.js";
+import {LinkKind} from "./types.js";
 
 export class OpenLinkViewModel extends ViewModel {
     constructor(options) {
@@ -37,6 +38,36 @@ export class OpenLinkViewModel extends ViewModel {
         } else {
             this._showLink();
         }
+
+        this._openLink();
+    }
+
+    async _openLink() {
+        // Proactively try to open the default Matrix client of the user.
+        let link = this._link;
+        let identifier = encodeURIComponent(link.identifier.substring(1));
+        let isRoomid = link.identifier.substring(0, 1) === '!';
+        let fragmentPath;
+        switch (link.kind) {
+            case LinkKind.User:
+                fragmentPath = `u/${identifier}?action=chat`;
+                break;
+            case LinkKind.Room:
+            case LinkKind.Event:
+                if (isRoomid)
+                    fragmentPath = `roomid/${identifier}`;
+                else
+                    fragmentPath = `r/${identifier}`;
+
+                if (link.kind === LinkKind.Event)
+                    fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
+                fragmentPath += '?action=join';
+                fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
+                break;
+            case LinkKind.Group:
+                return;
+        }
+        window.open(`matrix:${fragmentPath}`, '_self');
     }
 
     _showServerConsent() {

--- a/src/open/OpenLinkViewModel.js
+++ b/src/open/OpenLinkViewModel.js
@@ -21,7 +21,7 @@ import {PreviewViewModel} from "../preview/PreviewViewModel.js";
 import {ServerConsentViewModel} from "./ServerConsentViewModel.js";
 import {getLabelForLinkKind} from "../Link.js";
 import {orderedUnique} from "../utils/unique.js";
-import {LinkKind} from "./types.js";
+import {Link} from "../Link.js"
 
 export class OpenLinkViewModel extends ViewModel {
     constructor(options) {
@@ -44,30 +44,7 @@ export class OpenLinkViewModel extends ViewModel {
 
     async _openLink() {
         // Proactively try to open the default Matrix client of the user.
-        let link = this._link;
-        let identifier = encodeURIComponent(link.identifier.substring(1));
-        let isRoomid = link.identifier.substring(0, 1) === '!';
-        let fragmentPath;
-        switch (link.kind) {
-            case LinkKind.User:
-                fragmentPath = `u/${identifier}?action=chat`;
-                break;
-            case LinkKind.Room:
-            case LinkKind.Event:
-                if (isRoomid)
-                    fragmentPath = `roomid/${identifier}`;
-                else
-                    fragmentPath = `r/${identifier}`;
-
-                if (link.kind === LinkKind.Event)
-                    fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
-                fragmentPath += '?action=join';
-                fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
-                break;
-            case LinkKind.Group:
-                return;
-        }
-        window.open(`matrix:${fragmentPath}`, '_self');
+        window.open(Link.toMatrixUri(this._link), '_self');
     }
 
     _showServerConsent() {

--- a/src/open/clients/Fractal.js
+++ b/src/open/clients/Fractal.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {Maturity, Platform, LinkKind, FlathubLink} from "../types.js";
+import {Link} from "../../Link.js"
 
 /**
  * Information on how to deep link to a given matrix client.
@@ -31,29 +32,7 @@ export class Fractal {
 
     getDeepLink(platform, link) {
         if (platform === Platform.Linux) {
-            let identifier = encodeURIComponent(link.identifier.substring(1));
-            let isRoomid = link.identifier.substring(0, 1) === '!';
-            let fragmentPath;
-            switch (link.kind) {
-                case LinkKind.User:
-                    fragmentPath = `u/${identifier}?action=chat`;
-                    break;
-                case LinkKind.Room:
-                case LinkKind.Event:
-                    if (isRoomid)
-                        fragmentPath = `roomid/${identifier}`;
-                    else
-                        fragmentPath = `r/${identifier}`;
-
-                    if (link.kind === LinkKind.Event)
-                        fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
-                    fragmentPath += '?action=join';
-                    fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
-                    break;
-                case LinkKind.Group:
-                    return;
-            }
-            return `matrix:${fragmentPath}`;
+            return Link.toMatrixUri(link);
         }
     }
 

--- a/src/open/clients/NeoChat.js
+++ b/src/open/clients/NeoChat.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import {Maturity, Platform, LinkKind, FlathubLink, style} from "../types.js";
+import {Link} from "../../Link.js"
 
 export class NeoChat {
     get id() { return "neochat"; }
@@ -28,29 +29,7 @@ export class NeoChat {
     getMaturity(platform) { return Maturity.Beta; }
     getDeepLink(platform, link) {
         if (platform === Platform.Linux || platform === Platform.Windows) {
-            let identifier = encodeURIComponent(link.identifier.substring(1));
-            let isRoomid = link.identifier.substring(0, 1) === '!';
-            let fragmentPath;
-            switch (link.kind) {
-                case LinkKind.User:
-                    fragmentPath = `u/${identifier}?action=chat`;
-                    break;
-                case LinkKind.Room:
-                case LinkKind.Event:
-                    if (isRoomid)
-                        fragmentPath = `roomid/${identifier}`;
-                    else
-                        fragmentPath = `r/${identifier}`;
-
-                    if (link.kind === LinkKind.Event)
-                        fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
-                    fragmentPath += '?action=join';
-                    fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
-                    break;
-                case LinkKind.Group:
-                    return;
-            }
-            return `matrix:${fragmentPath}`;
+            return Link.toMatrixUri(link);
         }
     }
     canInterceptMatrixToLinks(platform) { return false; }

--- a/src/open/clients/Nheko.js
+++ b/src/open/clients/Nheko.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {Maturity, Platform, LinkKind, FlathubLink, WebsiteLink, style} from "../types.js";
+import {Link} from "../../Link.js"
 
 /**
  * Information on how to deep link to a given matrix client.
@@ -30,29 +31,7 @@ export class Nheko {
     getMaturity(platform) { return Maturity.Beta; }
     getDeepLink(platform, link) {
         if (platform === Platform.Linux || platform === Platform.Windows) {
-            let identifier = encodeURIComponent(link.identifier.substring(1));
-            let isRoomid = link.identifier.substring(0, 1) === '!';
-            let fragmentPath;
-            switch (link.kind) {
-                case LinkKind.User:
-                    fragmentPath = `u/${identifier}?action=chat`;
-                    break;
-                case LinkKind.Room:
-                case LinkKind.Event:
-                    if (isRoomid)
-                        fragmentPath = `roomid/${identifier}`;
-                    else
-                        fragmentPath = `r/${identifier}`;
-
-                    if (link.kind === LinkKind.Event)
-                        fragmentPath += `/e/${encodeURIComponent(link.eventId.substring(1))}`;
-                    fragmentPath += '?action=join';
-                    fragmentPath += link.servers.map(server => `&via=${encodeURIComponent(server)}`).join('');
-                    break;
-                case LinkKind.Group:
-                    return;
-            }
-            return `matrix:${fragmentPath}`;
+            return Link.toMatrixUri(link);
         }
     }
     canInterceptMatrixToLinks(platform) { return false; }


### PR DESCRIPTION
This should directly offer to open the default Matrix client a user has, if they have any and confirm the process. This should provide a more seamless experience once matrix: URIs are more widely adopted.
    
If the user doesn't have any such Matrix client, this will do nothing.

relates to #381 
relates to #355