### PR TITLE
Update Thunderbird flatpak app ID

### DIFF
--- a/src/open/clients/Thunderbird.js
+++ b/src/open/clients/Thunderbird.js
@@ -35,7 +35,7 @@ export class Thunderbird {
     getInstallLinks(platform) {
         const links = [];
         if (platform === Platform.Linux) {
-            links.push(new FlathubLink("org.mozilla.Thunderbird"));
+            links.push(new FlathubLink("org.mozilla.thunderbird"));
         }
         links.push(new WebsiteLink(this.homepage));
         return links;


### PR DESCRIPTION
Thunderbird has changed flatpak app ID: https://support.mozilla.org/en-US/kb/channel-choices-thunderbird-snap-and-flatpak#w_flatpak-beta-and-esr-changes-in-2026